### PR TITLE
Correctly handle binary attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,7 @@ name = "ldap-sync"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "bincode",
  "itertools 0.13.0",
  "ldap-poller",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = { version = "1.0.81", features = ["backtrace"] }
+base64 = "0.22.1"
 bincode = "1.3.3"
 itertools = "0.13.0"
 # error-stack = "0.4.1"

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -29,7 +29,12 @@ ldap:
     last_name: "sn"
     preferred_username: "displayName"
     email: "mail"
-    user_id: "uid"
+    user_id:
+      name: "uid"
+      # Some LDAP attributes are binary values; These should be marked
+      # explicitly. Most of the time it will work either way, but if
+      # this is not set any non-UTF8 values will fail to sync.
+      is_binary: true
     status: "shadowInactive"
     enable_value: 512
     disable_value: 514

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use tokio::sync::mpsc::Receiver;
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 
 mod config;
+mod user;
 mod zitadel;
 
 pub use config::{AttributeMapping, Config};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 mod config;
 mod zitadel;
 
-pub use config::Config;
+pub use config::{AttributeMapping, Config};
 use zitadel::Zitadel;
 
 /// Run the sync

--- a/src/user.rs
+++ b/src/user.rs
@@ -149,12 +149,23 @@ impl Display for User {
 }
 
 /// A structure that can either be a string or bytes
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) enum StringOrBytes {
 	/// A string
 	String(String),
 	/// A byte string
 	Bytes(Vec<u8>),
+}
+
+impl PartialEq for StringOrBytes {
+	fn eq(&self, other: &Self) -> bool {
+		match (self, other) {
+			(Self::String(s), Self::String(o)) => s == o,
+			(Self::String(s), Self::Bytes(o)) => s.as_bytes() == o,
+			(Self::Bytes(s), Self::String(o)) => s == o.as_bytes(),
+			(Self::Bytes(s), Self::Bytes(o)) => s == o,
+		}
+	}
 }
 
 impl Display for StringOrBytes {

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,0 +1,167 @@
+//! User data helpers
+use std::fmt::Display;
+
+use anyhow::{bail, Result};
+use base64::prelude::{Engine, BASE64_STANDARD};
+use ldap_poller::{ldap3::SearchEntry, SearchEntryExt};
+use zitadel_rust_client::{Email, Gender, Idp, ImportHumanUserRequest, Phone, Profile};
+
+use crate::config::{AttributeMapping, Config, FeatureFlag};
+
+/// Crate-internal representation of a Zitadel/LDAP user
+#[derive(Clone, Debug)]
+pub(crate) struct User {
+	/// The user's first name
+	pub(crate) first_name: StringOrBytes,
+	/// The user's last name
+	pub(crate) last_name: StringOrBytes,
+	/// The user's preferred username
+	pub(crate) preferred_username: StringOrBytes,
+	/// The user's email address
+	pub(crate) email: StringOrBytes,
+	/// The user's LDAP ID
+	pub(crate) ldap_id: StringOrBytes,
+	/// The user's phone number
+	pub(crate) phone: Option<StringOrBytes>,
+	/// Whether the user is enabled
+	pub(crate) enabled: bool,
+
+	/// Whether the user should be prompted to verify their email
+	pub(crate) needs_email_verification: bool,
+	/// Whether the user should be prompted to verify their phone number
+	pub(crate) needs_phone_verification: bool,
+	/// The ID of the identity provider to link with, if any
+	pub(crate) idp_id: Option<String>,
+}
+
+impl User {
+	/// Get a display name for the user
+	pub(crate) fn get_display_name(&self) -> String {
+		format!("{}, {}", self.last_name, self.first_name)
+	}
+
+	/// Return the name to be used in logs to identify this user
+	pub(crate) fn log_name(&self) -> String {
+		format!("email={}", &self.email)
+	}
+
+	/// Construct a user from an LDAP SearchEntry
+	pub(crate) fn try_from_search_entry(entry: SearchEntry, config: &Config) -> Result<Self> {
+		/// Read an attribute from the entry
+		fn read_entry(entry: &SearchEntry, attribute: &AttributeMapping) -> Result<StringOrBytes> {
+			match attribute {
+				AttributeMapping::OptionalBinary { name, is_binary: false }
+				| AttributeMapping::NoBinaryOption(name) => {
+					if let Some(attr) = entry.attr_first(name) {
+						return Ok(StringOrBytes::String(attr.to_owned()));
+					};
+				}
+				AttributeMapping::OptionalBinary { name, is_binary: true } => {
+					if let Some(binary_attr) = entry.bin_attr_first(name) {
+						return Ok(StringOrBytes::Bytes(binary_attr.to_vec()));
+					};
+
+					// If attributes encode as valid UTF-8, they will
+					// not be in the bin_attr list
+					if let Some(attr) = entry.attr_first(name) {
+						return Ok(StringOrBytes::Bytes(attr.as_bytes().to_vec()));
+					};
+				}
+			}
+
+			bail!("missing `{}` values for `{}`", attribute, entry.dn)
+		}
+
+		let enabled = read_entry(&entry, &config.ldap.attributes.status)?
+			!= StringOrBytes::String(config.ldap.attributes.disable_value.clone());
+		let first_name = read_entry(&entry, &config.ldap.attributes.first_name)?;
+		let last_name = read_entry(&entry, &config.ldap.attributes.last_name)?;
+		let preferred_username = read_entry(&entry, &config.ldap.attributes.preferred_username)?;
+		let email = read_entry(&entry, &config.ldap.attributes.email)?;
+		let user_id = read_entry(&entry, &config.ldap.attributes.user_id)?;
+		let phone = read_entry(&entry, &config.ldap.attributes.phone).ok();
+
+		Ok(Self {
+			first_name,
+			last_name,
+			preferred_username,
+			email,
+			ldap_id: user_id,
+			phone,
+			enabled,
+			needs_email_verification: config.feature_flags.contains(&FeatureFlag::VerifyEmail),
+			needs_phone_verification: config.feature_flags.contains(&FeatureFlag::VerifyPhone),
+			idp_id: config
+				.feature_flags
+				.contains(&FeatureFlag::SsoLogin)
+				.then(|| config.famedly.idp_id.clone()),
+		})
+	}
+
+	/// Get idp link as required by Zitadel
+	fn get_idps(&self) -> Vec<Idp> {
+		if let Some(idp_id) = self.idp_id.clone() {
+			vec![Idp {
+				config_id: idp_id,
+				external_user_id: self.ldap_id.clone().to_string(),
+				display_name: self.get_display_name(),
+			}]
+		} else {
+			vec![]
+		}
+	}
+}
+
+impl From<User> for ImportHumanUserRequest {
+	fn from(user: User) -> Self {
+		Self {
+			user_name: user.email.clone().to_string(),
+			profile: Some(Profile {
+				first_name: user.first_name.clone().to_string(),
+				last_name: user.last_name.clone().to_string(),
+				display_name: user.get_display_name(),
+				gender: Gender::Unspecified.into(), // 0 means "unspecified",
+				nick_name: user.ldap_id.clone().to_string(),
+				preferred_language: String::default(),
+			}),
+			email: Some(Email {
+				email: user.email.clone().to_string(),
+				is_email_verified: !user.needs_email_verification,
+			}),
+			phone: user.phone.as_ref().map(|phone| Phone {
+				phone: phone.to_owned().to_string(),
+				is_phone_verified: !user.needs_phone_verification,
+			}),
+			password: String::default(),
+			hashed_password: None,
+			password_change_required: false,
+			request_passwordless_registration: true,
+			otp_code: String::default(),
+			idps: user.get_idps(),
+		}
+	}
+}
+
+impl Display for User {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "email={}", &self.email)
+	}
+}
+
+/// A structure that can either be a string or bytes
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum StringOrBytes {
+	/// A string
+	String(String),
+	/// A byte string
+	Bytes(Vec<u8>),
+}
+
+impl Display for StringOrBytes {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			StringOrBytes::String(value) => write!(f, "{}", value),
+			StringOrBytes::Bytes(value) => write!(f, "{}", BASE64_STANDARD.encode(value)),
+		}
+	}
+}

--- a/src/zitadel.rs
+++ b/src/zitadel.rs
@@ -1,17 +1,17 @@
 //! Helper functions for submitting data to Zitadel
-use std::fmt::Display;
-
 use anyhow::{anyhow, bail, Result};
-use base64::prelude::{Engine, BASE64_STANDARD};
 use itertools::Itertools;
-use ldap_poller::{ldap3::SearchEntry, SearchEntryExt};
+use ldap_poller::ldap3::SearchEntry;
 use uuid::{uuid, Uuid};
 use zitadel_rust_client::{
 	error::{Error as ZitadelError, TonicErrorCode},
-	Email, Gender, Idp, ImportHumanUserRequest, Phone, Profile, Zitadel as ZitadelClient,
+	Zitadel as ZitadelClient,
 };
 
-use crate::config::{AttributeMapping, Config, FeatureFlag};
+use crate::{
+	config::Config,
+	user::{StringOrBytes, User},
+};
 
 /// The Famedly UUID namespace to use to generate v5 UUIDs.
 const FAMEDLY_NAMESPACE: Uuid = uuid!("d9979cff-abee-4666-bc88-1ec45a843fb8");
@@ -316,157 +316,5 @@ impl Zitadel {
 		tracing::info!("Successfully imported user {}", user.email);
 
 		Ok(())
-	}
-}
-
-/// A structure that can either be a string or bytes
-#[derive(Clone, Debug, PartialEq)]
-enum StringOrBytes {
-	/// A string
-	String(String),
-	/// A byte string
-	Bytes(Vec<u8>),
-}
-
-impl Display for StringOrBytes {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			StringOrBytes::String(value) => write!(f, "{}", value),
-			StringOrBytes::Bytes(value) => write!(f, "{}", BASE64_STANDARD.encode(value)),
-		}
-	}
-}
-
-/// Crate-internal representation of a Zitadel/LDAP user
-#[derive(Clone, Debug)]
-struct User {
-	/// The user's first name
-	first_name: StringOrBytes,
-	/// The user's last name
-	last_name: StringOrBytes,
-	/// The user's preferred username
-	preferred_username: StringOrBytes,
-	/// The user's email address
-	email: StringOrBytes,
-	/// The user's LDAP ID
-	ldap_id: StringOrBytes,
-	/// The user's phone number
-	phone: Option<StringOrBytes>,
-	/// Whether the user is enabled
-	enabled: bool,
-
-	/// Whether the user should be prompted to verify their email
-	needs_email_verification: bool,
-	/// Whether the user should be prompted to verify their phone number
-	needs_phone_verification: bool,
-	/// The ID of the identity provider to link with, if any
-	idp_id: Option<String>,
-}
-
-impl User {
-	/// Get a display name for the user
-	fn get_display_name(&self) -> String {
-		format!("{}, {}", self.last_name, self.first_name)
-	}
-
-	/// Get idp link as required by Zitadel
-	fn get_idps(&self) -> Vec<Idp> {
-		if let Some(idp_id) = self.idp_id.clone() {
-			vec![Idp {
-				config_id: idp_id,
-				external_user_id: self.ldap_id.clone().to_string(),
-				display_name: self.get_display_name(),
-			}]
-		} else {
-			vec![]
-		}
-	}
-
-	/// Return the name to be used in logs to identify this user
-	fn log_name(&self) -> String {
-		format!("email={}", &self.email)
-	}
-
-	/// Construct a user from an LDAP SearchEntry
-	fn try_from_search_entry(entry: SearchEntry, config: &Config) -> Result<Self> {
-		/// Read an attribute from the entry
-		fn read_entry(entry: &SearchEntry, attribute: &AttributeMapping) -> Result<StringOrBytes> {
-			match attribute {
-				AttributeMapping::OptionalBinary { name, is_binary: false }
-				| AttributeMapping::NoBinaryOption(name) => {
-					if let Some(attr) = entry.attr_first(name) {
-						return Ok(StringOrBytes::String(attr.to_owned()));
-					};
-				}
-				AttributeMapping::OptionalBinary { name, is_binary: true } => {
-					if let Some(binary_attr) = entry.bin_attr_first(name) {
-						return Ok(StringOrBytes::Bytes(binary_attr.to_vec()));
-					};
-
-					// If attributes encode as valid UTF-8, they will
-					// not be in the bin_attr list
-					if let Some(attr) = entry.attr_first(name) {
-						return Ok(StringOrBytes::Bytes(attr.as_bytes().to_vec()));
-					};
-				}
-			}
-
-			bail!("missing `{}` values for `{}`", attribute, entry.dn)
-		}
-
-		let enabled = read_entry(&entry, &config.ldap.attributes.status)?
-			!= StringOrBytes::String(config.ldap.attributes.disable_value.clone());
-		let first_name = read_entry(&entry, &config.ldap.attributes.first_name)?;
-		let last_name = read_entry(&entry, &config.ldap.attributes.last_name)?;
-		let preferred_username = read_entry(&entry, &config.ldap.attributes.preferred_username)?;
-		let email = read_entry(&entry, &config.ldap.attributes.email)?;
-		let user_id = read_entry(&entry, &config.ldap.attributes.user_id)?;
-		let phone = read_entry(&entry, &config.ldap.attributes.phone).ok();
-
-		Ok(Self {
-			first_name,
-			last_name,
-			preferred_username,
-			email,
-			ldap_id: user_id,
-			phone,
-			enabled,
-			needs_email_verification: config.feature_flags.contains(&FeatureFlag::VerifyEmail),
-			needs_phone_verification: config.feature_flags.contains(&FeatureFlag::VerifyPhone),
-			idp_id: config
-				.feature_flags
-				.contains(&FeatureFlag::SsoLogin)
-				.then(|| config.famedly.idp_id.clone()),
-		})
-	}
-}
-
-impl From<User> for ImportHumanUserRequest {
-	fn from(user: User) -> Self {
-		Self {
-			user_name: user.email.clone().to_string(),
-			profile: Some(Profile {
-				first_name: user.first_name.clone().to_string(),
-				last_name: user.last_name.clone().to_string(),
-				display_name: user.get_display_name(),
-				gender: Gender::Unspecified.into(), // 0 means "unspecified",
-				nick_name: user.ldap_id.clone().to_string(),
-				preferred_language: String::default(),
-			}),
-			email: Some(Email {
-				email: user.email.clone().to_string(),
-				is_email_verified: !user.needs_email_verification,
-			}),
-			phone: user.phone.as_ref().map(|phone| Phone {
-				phone: phone.to_owned().to_string(),
-				is_phone_verified: !user.needs_phone_verification,
-			}),
-			password: String::default(),
-			hashed_password: None,
-			password_change_required: false,
-			request_passwordless_registration: true,
-			otp_code: String::default(),
-			idps: user.get_idps(),
-		}
 	}
 }

--- a/src/zitadel.rs
+++ b/src/zitadel.rs
@@ -1,4 +1,6 @@
 //! Helper functions for submitting data to Zitadel
+use std::fmt::Display;
+
 use anyhow::{anyhow, bail, Result};
 use itertools::Itertools;
 use ldap_poller::ldap3::SearchEntry;
@@ -58,7 +60,7 @@ impl Zitadel {
 			let sync_status = self.import_user(&user).await;
 
 			if let Err(error) = sync_status {
-				tracing::error!("Failed to sync user `{}`: {}", user.ldap_id, error);
+				tracing::error!("Failed to sync user `{}`: {}", user.log_name(), error);
 			};
 		}
 
@@ -106,7 +108,7 @@ impl Zitadel {
 			let status = self.delete_user(&user).await;
 
 			if let Err(error) = status {
-				tracing::error!("Failed to delete user `{}`: {}`", user.ldap_id, error);
+				tracing::error!("Failed to delete user `{}`: {}`", user.log_name(), error);
 			}
 		}
 
@@ -114,7 +116,7 @@ impl Zitadel {
 			let status = self.import_user(&user).await;
 
 			if let Err(error) = status {
-				tracing::error!("Failed to re-create user `{}`: {}", user.ldap_id, error);
+				tracing::error!("Failed to re-create user `{}`: {}", user.log_name(), error);
 			}
 		}
 
@@ -122,7 +124,7 @@ impl Zitadel {
 			let status = self.update_user(&old, &new).await;
 
 			if let Err(error) = status {
-				tracing::error!("Failed to update user `{}`: {}", new.ldap_id, error);
+				tracing::error!("Failed to update user `{}`: {}", new.log_name(), error);
 			}
 		}
 
@@ -312,7 +314,7 @@ impl Zitadel {
 }
 
 /// Crate-internal representation of a Zitadel/LDAP user
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct User {
 	/// The user's first name
 	first_name: String,
@@ -354,6 +356,11 @@ impl User {
 		} else {
 			vec![]
 		}
+	}
+
+	/// Return the name to be used in logs to identify this user
+	fn log_name(&self) -> String {
+		format!("email={}", &self.email)
 	}
 
 	/// Construct a user from an LDAP SearchEntry

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashSet, path::Path, time::Duration};
 
+use base64::prelude::{Engine, BASE64_STANDARD};
 use ldap3::{Ldap as LdapClient, LdapConnAsync, LdapConnSettings, Mod};
 use ldap_sync::{sync_ldap_users_to_zitadel, Config};
 use tempfile::TempDir;
@@ -334,6 +335,64 @@ async fn test_e2e_no_phone() {
 	} else {
 		panic!("user lacks details");
 	};
+}
+
+#[test(tokio::test)]
+#[test_log(default_log_filter = "debug")]
+async fn test_e2e_binary_attr() {
+	let mut config = config().await.clone();
+
+	// OpenLDAP checks if types match, so we need to use an attribute
+	// that can actually be binary.
+	"userSMIMECertificate".clone_into(&mut config.ldap.attributes.preferred_username);
+
+	let mut ldap = Ldap::new().await;
+	ldap.create_user(
+		"Bob",
+		"Tables",
+		"Bobby",
+		"binary@famedly.de",
+		Some("+12015550123"),
+		"binary",
+		false,
+	)
+	.await;
+	ldap.change_user(
+		"binary",
+		vec![(
+			"userSMIMECertificate".as_bytes(),
+			// It's important that this is invalid UTF-8
+			HashSet::from([[0xA0, 0xA1].as_slice()]),
+		)],
+	)
+	.await;
+
+	sync_ldap_users_to_zitadel(config.clone()).await.expect("syncing failed");
+
+	let zitadel = open_zitadel_connection().await;
+	let user = zitadel
+		.get_user_by_login_name("binary@famedly.de")
+		.await
+		.expect("could not query Zitadel users");
+
+	assert!(user.is_some());
+
+	if let Some(user) = user {
+		let preferred_username = zitadel
+			.get_user_metadata(
+				Some(config.famedly.organization_id.clone()),
+				&user.id,
+				"preferred_username",
+			)
+			.await
+			.expect("could not get user metadata");
+
+		assert_eq!(
+			preferred_username
+				.map(|u| BASE64_STANDARD.decode(u).expect("failed to decode binary attr")),
+			Some([0xA0, 0xA1].to_vec())
+		);
+	}
 }
 
 struct Ldap {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -399,7 +399,11 @@ impl Ldap {
 		tracing::info!("Successfully added test user");
 	}
 
-	async fn change_user(&mut self, uid: &str, changes: Vec<(&str, HashSet<&str>)>) {
+	async fn change_user<S: AsRef<[u8]> + Eq + core::hash::Hash + Send>(
+		&mut self,
+		uid: &str,
+		changes: Vec<(S, HashSet<S>)>,
+	) {
 		let mods = changes
 			.into_iter()
 			.map(|(attribute, changes)| Mod::Replace(attribute, changes))

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -412,6 +412,8 @@ impl Ldap {
 		self.client
 			.modify(&format!("uid={},{}", uid, config().await.ldap.base_dn.as_str()), mods)
 			.await
+			.expect("failed to modify user")
+			.success()
 			.expect("failed to modify user");
 	}
 
@@ -419,6 +421,8 @@ impl Ldap {
 		self.client
 			.delete(&format!("uid={},{}", uid, config().await.ldap.base_dn.as_str()))
 			.await
+			.expect("failed to delete user")
+			.success()
 			.expect("failed to delete user");
 	}
 }

--- a/tests/environment/config.template.yaml
+++ b/tests/environment/config.template.yaml
@@ -13,7 +13,9 @@ ldap:
     email: "mail"                     # objectClass: inetOrgPerson
     phone: "telephoneNumber"          # objectClass: person
     user_id: "uid"
-    status: "shadowInactive"          # objectClass: shadowAccount
+    status:
+      name: "shadowInactive"          # objectClass: shadowAccount
+      is_binary: false
     enable_value: 512
     disable_value: 514
   tls:


### PR DESCRIPTION
Fixes #3

Binary attributes are synced encoded in base64 to zitadel - zitadel *should* handle that correctly, see https://github.com/zitadel/zitadel/pull/8210.