### PR TITLE
feat!: Implement bitflag for status attribute with multiple disable values

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -41,9 +41,12 @@ ldap:
       # explicitly. Most of the time it will work either way, but if
       # this is not set any non-UTF8 values will fail to sync.
       is_binary: true
-    status: "shadowInactive"
-    enable_value: 512
-    disable_value: 514
+    # Status flag for the user. This is read as a big-endian integer. Normally userAccountControl in AD.
+    status: "shadowFlag"
+    # Vector of bitmasks that marks the user as disabled. Tested on status.
+    # (for example ACCOUNTDISABLE=0x2 and LOCKOUT=0x10 in AD)
+    # Decimal (or hex) representation of the specific flag mask
+    disable_bitmasks: [0x2, 0x10]
     # Phone numbers are the only optional attribute, if a user does
     # not have a phone number this will be silently ignored
     phone: "telephoneNumber"

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,12 +167,12 @@ pub struct LdapAttributesMapping {
 	pub phone: AttributeMapping,
 	/// Attribute for the user's unique ID
 	pub user_id: AttributeMapping,
-	/// This attribute shows the account status (LDAP = Enabled, accountStatus)
+	/// This attribute shows the account status (It expects an i32 like
+	/// userAccountControl in AD)
 	pub status: AttributeMapping,
-	/// Marks an account as enabled (LDAP = TRUE, active)
-	pub enable_value: String,
-	/// Marks an account as enabled (LDAP = FALSE, inactive)
-	pub disable_value: String,
+	/// Marks an account as disabled (for example userAccountControl: bit flag
+	/// ACCOUNTDISABLE would be 2)
+	pub disable_bitmasks: Vec<i32>,
 	/// Last modified
 	pub last_modified: Option<AttributeMapping>,
 }
@@ -297,10 +297,9 @@ mod tests {
             phone: "telephoneNumber"
             user_id: "uid"
             status:
-              name: "shadowInactive"
+              name: "shadowFlag"
               is_binary: false
-            enable_value: 512
-            disable_value: 514
+            disable_bitmasks: [0x2, 0x10]
           tls:
             client_key: ./tests/environment/certs/client.key
             client_certificate: ./tests/environment/certs/client.crt
@@ -349,7 +348,7 @@ mod tests {
 
 		assert_eq!(
 			Into::<ldap_poller::Config>::into(config.ldap).attributes.get_attr_filter(),
-			vec!["uid", "shadowInactive", "cn", "sn", "displayName", "mail", "telephoneNumber"]
+			vec!["uid", "shadowFlag", "cn", "sn", "displayName", "mail", "telephoneNumber"]
 		);
 	}
 

--- a/tests/environment/config.template.yaml
+++ b/tests/environment/config.template.yaml
@@ -15,10 +15,9 @@ ldap:
     phone: "telephoneNumber"          # objectClass: person
     user_id: "uid"
     status:
-      name: "shadowInactive"          # objectClass: shadowAccount
+      name: "shadowFlag"          # objectClass: shadowAccount
       is_binary: false
-    enable_value: 512
-    disable_value: 514
+    disable_bitmasks: [0x2, 0x10]
   tls:
     client_key: ./tests/environment/certs/client.key
     client_certificate: ./tests/environment/certs/client.crt


### PR DESCRIPTION
Closes #12 

Removes the enable_value and assumes an account is enabled by default.
Expects the status attribute to be parsable as i32 like userAccountControl on AD.
It renames the disable_values to disable_bitflags which are tested against the status attribute like for example ACCOUNTDISABLE (2) for AD.