### PR TITLE
fix: Don't set passwordless registration for users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "zitadel-rust-client"
 version = "0.1.0"
-source = "git+https://github.com/famedly/zitadel-rust-client#e2f507076b6062cab48387852c55e99eb7d7ec31"
+source = "git+https://github.com/famedly/zitadel-rust-client#340ca3e4de47e0d0338f4a01baa25b73a578a3c4"
 dependencies = [
  "headers",
  "hyper",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,15 @@ mod config;
 mod user;
 mod zitadel;
 
-pub use config::{AttributeMapping, Config};
+pub use config::{AttributeMapping, Config, FeatureFlag};
 use zitadel::Zitadel;
 
 /// Run the sync
 pub async fn sync_ldap_users_to_zitadel(config: Config) -> Result<()> {
+	if !config.feature_flags.contains(&FeatureFlag::SsoLogin) {
+		anyhow::bail!("Non-SSO configuration is currently not supported");
+	}
+
 	let cache = read_cache(&config.cache_path).await?;
 	let zitadel = Zitadel::new(&config).await?;
 	let (mut ldap_client, ldap_receiver) = Ldap::new(config.clone().ldap.into(), cache);

--- a/src/user.rs
+++ b/src/user.rs
@@ -142,7 +142,7 @@ impl From<User> for ImportHumanUserRequest {
 			password: String::default(),
 			hashed_password: None,
 			password_change_required: false,
-			request_passwordless_registration: true,
+			request_passwordless_registration: false,
 			otp_code: String::default(),
 			idps: user.get_idps(),
 		}

--- a/tests/environment/config.template.yaml
+++ b/tests/environment/config.template.yaml
@@ -30,7 +30,8 @@ famedly:
   key_file: tests/environment/zitadel/service-user.json
   organization_id: @ORGANIZATION_ID@
   project_id: @PROJECT_ID@
-  idp_id: tbd
+  idp_id: @IDP_ID@
 
-feature_flags: []
+feature_flags:
+  - SsoLogin
 cache_path: ./test


### PR DESCRIPTION
This is *not* enabling users to do their registration without a password, it instead configures setting up registration with authenticators.

Fixes #23 and #4