### PR TITLE
Lock the versions of various tooling used in testing

### DIFF
--- a/tests/environment/docker-compose.yaml
+++ b/tests/environment/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   ldap:
-    image: bitnami/openldap:latest
+    image: bitnami/openldap:2.5.18
     ports:
       - 1389:1389
       - 1636:1636
@@ -42,7 +42,7 @@ services:
         condition: 'service_healthy'
 
   zitadel:
-    image: ghcr.io/zitadel/zitadel:latest
+    image: ghcr.io/zitadel/zitadel:v2.58.3
     command: start-from-init --masterkey "MasterkeyNeedsToHave32Characters" --tlsMode disabled --config /zitadel-config/zitadel-config.yaml --steps /zitadel-config/zitadel-init.yaml
     ports:
       - 8080:8080

--- a/tests/environment/test-setup/Dockerfile
+++ b/tests/environment/test-setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/openldap:latest
+FROM bitnami/openldap:2.5.18
 
 USER root
 
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get upgrade -y && \
 	apt-get install --yes -t bookworm-backports golang-go && \
 	apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-RUN GOPATH=/ go install github.com/zitadel/zitadel-tools@latest
+RUN GOPATH=/ go install github.com/zitadel/zitadel-tools@v0.5.0

--- a/tests/environment/test-setup/Dockerfile
+++ b/tests/environment/test-setup/Dockerfile
@@ -2,8 +2,11 @@ FROM bitnami/openldap:latest
 
 USER root
 
+RUN echo 'deb http://deb.debian.org/debian bookworm-backports main' >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get upgrade -y && \
-	apt-get install --yes curl golang-go jq && \
+	apt-get install --yes curl jq && \
+	apt-get install --yes -t bookworm-backports golang-go && \
 	apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 RUN GOPATH=/ go install github.com/zitadel/zitadel-tools@latest


### PR DESCRIPTION
A recent change in the zitadel-tools upstream started requiring go 1.21, which broke our test suite. This should fix it, and I changed all our tooling to use fixed versions while I was at it (except stuff installed on debian, but that should be reasonably stable) - I intended to do that earlier, but forgot.