### PR TITLE
feat(zitadel): Remove the feature setting custom Zitadel IDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow_ext::{Context, Result, bail};
 use futures::{StreamExt, TryStreamExt};
 use user::User;
-use zitadel::{SkipableZitadelResult, Zitadel};
+use zitadel::{SkippableZitadelResult, Zitadel};
 use zitadel_rust_client::v2::users::{SetHumanProfile, UpdateHumanUserRequest};
 
 mod config;

--- a/src/zitadel.rs
+++ b/src/zitadel.rs
@@ -509,7 +509,7 @@ trait GenericCombinatorsExt {
 impl<X> GenericCombinatorsExt for X {}
 
 /// Helper trait for skippable zitadel errors to use with `[SkippedErrors]`
-pub trait SkipableZitadelResult<X: Send> {
+pub trait SkippableZitadelResult<X: Send> {
 	/// Helper method for skippable zitadel errors to use with `[SkippedErrors]`
 	fn skip_zitadel_error(
 		self,
@@ -518,7 +518,7 @@ pub trait SkipableZitadelResult<X: Send> {
 	) -> Option<X>;
 }
 
-impl<X: Send> SkipableZitadelResult<X> for Result<X> {
+impl<X: Send> SkippableZitadelResult<X> for Result<X> {
 	fn skip_zitadel_error(
 		self,
 		operation: &'static str,

--- a/src/zitadel.rs
+++ b/src/zitadel.rs
@@ -213,8 +213,7 @@ impl<'s> Zitadel<'s> {
 		.with_organization(
 			Organization::new().with_org_id(self.zitadel_config.organization_id.clone()),
 		)
-		.with_metadata(metadata)
-		.with_user_id(imported_user.localpart.clone()); // Set the Zitadel userId to the localpart
+		.with_metadata(metadata);
 
 		if let Some(phone) = imported_user.phone.clone() {
 			user.set_phone(

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1218,7 +1218,6 @@ async fn test_e2e_csv_sync() {
 		.expect("could not query Zitadel users");
 	let user = user.expect("could not find user");
 	assert_eq!(user.user_name, "john.doe@example.com");
-	assert_eq!(user.id, "john.doe", "Unexpected Zitadel userId");
 
 	if let Some(UserType::Human(user)) = user.r#type {
 		let profile = user.profile.expect("user lacks a profile");
@@ -1249,8 +1248,9 @@ async fn test_e2e_csv_sync() {
 	let localpart = zitadel
 		.get_user_metadata(Some(config.zitadel.organization_id.clone()), &user.id, "localpart")
 		.await
-		.expect("could not get user metadata");
-	assert_eq!(localpart, Some(user.id.clone()), "Localpart metadata should match userId");
+		.expect("could not get user metadata")
+		.expect("missing localpart");
+	assert_eq!(localpart, "john.doe", "Unexpected Zitadel userId for user without localpart");
 
 	let grants = zitadel
 		.list_user_grants(&config.zitadel.organization_id, &user.id)
@@ -1268,14 +1268,13 @@ async fn test_e2e_csv_sync() {
 
 	let user = user.expect("could not find user");
 	assert_eq!(user.user_name, "jane.smith@example.com");
-	let uuid = Uuid::new_v5(&FAMEDLY_NAMESPACE, "jane.smith@example.com".as_bytes());
-	assert_eq!(user.id, uuid.to_string(), "Unexpected Zitadel userId for user without localpart");
 
+	let uuid = Uuid::new_v5(&FAMEDLY_NAMESPACE, "jane.smith@example.com".as_bytes());
 	let localpart = zitadel
 		.get_user_metadata(Some(config.zitadel.organization_id.clone()), &user.id, "localpart")
 		.await
 		.expect("could not get user metadata");
-	assert_eq!(localpart, Some(user.id), "Localpart metadata should match userId");
+	assert_eq!(localpart, Some(uuid.to_string()), "Localpart metadata should match userId");
 
 	// Re-import an existing user to update (as checked by unique email)
 	let csv_content = indoc::indoc! {r#"
@@ -1283,6 +1282,14 @@ async fn test_e2e_csv_sync() {
     john.doe@example.com,Changed_Name,Changed_Surname,+2222222222,new.localpart
   "#};
 	let _file = temp_csv_file(&mut config, csv_content);
+
+	let user_id = zitadel
+		.get_user_by_login_name("john.doe@example.com")
+		.await
+		.expect("could not query Zitadel users")
+		.expect("Must be able to get the user pre-sync")
+		.id;
+
 	perform_sync(config.clone()).await.expect("syncing failed");
 
 	let user = zitadel
@@ -1292,7 +1299,7 @@ async fn test_e2e_csv_sync() {
 
 	let user = user.expect("could not find user");
 	assert_eq!(user.user_name, "john.doe@example.com");
-	assert_eq!(user.id, "john.doe", "Zitadel userId should not change");
+	assert_eq!(user.id, user_id, "Zitadel userId should not change");
 
 	if let Some(UserType::Human(user)) = user.r#type {
 		let profile = user.profile.expect("user lacks a profile");
@@ -1314,7 +1321,7 @@ async fn test_e2e_csv_sync() {
 		.get_user_metadata(Some(config.zitadel.organization_id.clone()), &user.id, "localpart")
 		.await
 		.expect("could not get user metadata");
-	assert_eq!(localpart, Some(user.id), "Localpart metadata should match userId");
+	assert_eq!(localpart, Some("john.doe".to_owned()),);
 }
 
 #[test(tokio::test)]

--- a/tests/environment/docker-compose.yaml
+++ b/tests/environment/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     entrypoint: /certs/generate-certs.sh
 
   ldap:
-    image: bitnami/openldap:2.5.18
+    image: registry.famedly.net/public-ecr-aws/bitnami/openldap:2.6
     ports:
       - 1389:1389
       - 1636:1636

--- a/tests/environment/test-setup/Dockerfile
+++ b/tests/environment/test-setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/openldap:2.5.18
+FROM registry.famedly.net/public-ecr-aws/bitnami/openldap:2.6
 
 USER root
 


### PR DESCRIPTION
This feature is purely cosmetic, we've avoided using it for anything; As expected, a consistency bug was caused by it (likely due to bad handling of the historic status of this as an arbitrarily generated ID), though the bug happened upstream in Zitadel.