### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: famedly/backend-build-workflows/.github/workflows/docker-backend.yml@v3
+    uses: famedly/backend-build-workflows/.github/workflows/docker-backend.yml@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
     secrets: inherit
     with:
       targets: famedly-sync-agent

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
     container: registry.famedly.net/docker-oss/rust-container:nightly
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
 
       - name: Set up Rust
-        uses: famedly/backend-build-workflows/.github/actions/rust-prepare@main
+        uses: famedly/backend-build-workflows/.github/actions/rust-prepare@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
         with:
           gitlab_ssh: ${{ secrets.CI_SSH_PRIVATE_KEY}}
           gitlab_user: ${{ secrets.GITLAB_USER }}
@@ -58,12 +58,12 @@ jobs:
         run: "mv target/release/${{ github.event.repository.name }} target/release/${{ matrix.asset_name }}"
 
       - name: Attest
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@10334b5f1e684784025c3fc0a277c88c19089275
         with:
           subject-path: '${{ github.workspace }}/target/release/${{ matrix.asset_name }}'
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-${{ matrix.asset_name }}
           path: '${{ github.workspace }}/target/release/${{ matrix.asset_name }}'
@@ -77,10 +77,10 @@ jobs:
     container: registry.famedly.net/docker-oss/rust-container:nightly
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
 
       - name: Set up Rust
-        uses: famedly/backend-build-workflows/.github/actions/rust-prepare@main
+        uses: famedly/backend-build-workflows/.github/actions/rust-prepare@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
         with:
           gitlab_ssh: ${{ secrets.CI_SSH_PRIVATE_KEY}}
           gitlab_user: ${{ secrets.GITLAB_USER }}
@@ -110,21 +110,21 @@ jobs:
         run: cargo cyclonedx -f json
 
       - name: Attest SPDX SBOM
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@10334b5f1e684784025c3fc0a277c88c19089275
         with:
           subject-path: '${{ github.workspace }}/${{ github.event.repository.name }}.spdx.json'
       - name: Attest CycloneDX SBOM
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@10334b5f1e684784025c3fc0a277c88c19089275
         with:
           subject-path: '${{ github.workspace }}/${{ github.event.repository.name }}.cdx.json'
 
       - name: Upload SPDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-sbom-spdx
           path: '${{ github.workspace }}/${{ github.event.repository.name}}.spdx.json'
       - name: Upload CycloneDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-sbom-cdx
           path: '${{ github.workspace }}/${{ github.event.repository.name }}.cdx.json'
@@ -134,7 +134,7 @@ jobs:
     needs: [build, sbom]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317
         with:
           pattern: release-*
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,13 @@ jobs:
           gitlab_pass: ${{ secrets.GITLAB_PASS }}
 
       - name: Caching
-        uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
+        uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68
         with:
           cache-on-failure: true
           cache-all-crates: true
 
       - name: Install additional cargo tooling
-        uses: taiki-e/cache-cargo-install-action@3d5e3efe44b020826abe522d18cb4457042280ef
+        uses: taiki-e/cache-cargo-install-action@50baf549964a2319a419344c87f6a2141748e7f5
         with:
           tool: cargo-auditable
 
@@ -87,18 +87,18 @@ jobs:
           gitlab_pass: ${{ secrets.GITLAB_PASS }}
 
       - name: Caching
-        uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
+        uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68
         with:
           cache-on-failure: true
           cache-all-crates: true
 
       - name: Install cargo-sbom
-        uses: taiki-e/cache-cargo-install-action@3d5e3efe44b020826abe522d18cb4457042280ef
+        uses: taiki-e/cache-cargo-install-action@50baf549964a2319a419344c87f6a2141748e7f5
         with:
           tool: cargo-sbom
 
       - name: Install cyclonedx-rust-cargo
-        uses: taiki-e/cache-cargo-install-action@3d5e3efe44b020826abe522d18cb4457042280ef
+        uses: taiki-e/cache-cargo-install-action@50baf549964a2319a419344c87f6a2141748e7f5
         with:
           tool: cargo-cyclonedx
 
@@ -141,7 +141,7 @@ jobs:
           merge-multiple: true
 
       - name: Create release
-        uses: softprops/action-gh-release@79721680dfc87fb0f44dfe65df68961056d55c38
+        uses: softprops/action-gh-release@403a5240f3837fa857f642062e05aad6bb3391ca
         with:
           files: artifacts/*
           prerelease: "${{ contains(github.ref_name, 'rc') }}"

--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout current repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
 
     - uses: famedly/backend-build-workflows/.github/actions/rust-prepare@main
       with:
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout current repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
 
     - uses: famedly/backend-build-workflows/.github/actions/rust-prepare@main
       with:

--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -32,7 +32,7 @@ jobs:
         gitlab_pass: ${{ secrets.GITLAB_PASS }}
 
     - name: Caching
-      uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
+      uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68
       with:
         cache-on-failure: true
         cache-all-crates: true
@@ -73,7 +73,7 @@ jobs:
       run: rustup component add llvm-tools-preview --toolchain stable-x86_64-unknown-linux-gnu
 
     - name: Caching
-      uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
+      uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68
       with:
         cache-on-failure: true
         cache-all-crates: true
@@ -96,12 +96,12 @@ jobs:
         docker compose --project-directory ./tests/environment logs
 
     - name: Codecov - Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@ca0a928a4cb3911011e868128a5cd90437c12db1
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         files: lcov.info
 
     - name: Codecov - Upload test results
-      uses: codecov/test-results-action@v1
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
       with:
         token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
## Summary
- Update GitHub Actions in workflows to the latest upstream default-branch commit SHAs.
- Keep existing action paths and only replace refs after `@`.

## Verification
- Checked generated diff to include only `.github/**/*.yml` / `.github/**/*.yaml` workflow action refs.
- CI on this PR should validate the updated action versions.